### PR TITLE
Testing build issues

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,1 @@
-HOSTNAME="neurobionics"
+HOSTNAME="luceleganspi"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ on:
     inputs:
       host_name:
         description: "Hostname"
-        default: LuCelegans
+        default: luceleganspi
         required: true
       user:
         description: "Username"

--- a/main.Pifile
+++ b/main.Pifile
@@ -64,7 +64,7 @@ RUN bash -c "sudo chown -R ${user} /etc/automagic-ap"
 
 # Installing webmin
 
-RUN bash -c "find /var/log/ -type f -regex '.*\.[0-9]+\.gz$' -delete"
+RUN bash -c "truncate –size 0 /var/log/dpkg.log"
 
 RUN bash -c 'echo "deb https://download.webmin.com/download/repository sarge contrib" >> /etc/apt/sources.list'
 RUN bash -c "wget http://www.webmin.com/jcameron-key.asc"

--- a/main.Pifile
+++ b/main.Pifile
@@ -64,11 +64,11 @@ RUN bash -c "sudo chown -R ${user} /etc/automagic-ap"
 
 # Installing webmin
 
+RUN bash -c "find /var/log/ -type f -regex '.*\.[0-9]+\.gz$' -delete"
+
 RUN bash -c 'echo "deb https://download.webmin.com/download/repository sarge contrib" >> /etc/apt/sources.list'
 RUN bash -c "wget http://www.webmin.com/jcameron-key.asc"
 RUN apt-key add jcameron-key.asc
-
-RUN bash -c "sudo find /var/log/ -type f -regex '.*\.[0-9]+\.gz$' -delete"
 
 RUN apt update
 RUN apt install -y webmin

--- a/main.Pifile
+++ b/main.Pifile
@@ -64,7 +64,7 @@ RUN bash -c "sudo chown -R ${user} /etc/automagic-ap"
 
 # Installing webmin
 
-RUN bash -c "truncate –-size 0 /var/log/dpkg.log"
+RUN bash -c "sudo apt autoremove"
 
 RUN bash -c 'echo "deb https://download.webmin.com/download/repository sarge contrib" >> /etc/apt/sources.list'
 RUN bash -c "wget http://www.webmin.com/jcameron-key.asc"

--- a/main.Pifile
+++ b/main.Pifile
@@ -68,6 +68,8 @@ RUN bash -c 'echo "deb https://download.webmin.com/download/repository sarge con
 RUN bash -c "wget http://www.webmin.com/jcameron-key.asc"
 RUN apt-key add jcameron-key.asc
 
+RUN bash -c "sudo find /var/log/ -type f -regex '.*\.[0-9]+\.gz$' -delete"
+
 RUN apt update
 RUN apt install -y webmin
 

--- a/main.Pifile
+++ b/main.Pifile
@@ -1,6 +1,6 @@
 FROM https://downloads.raspberrypi.org/raspios_lite_armhf/images/raspios_lite_armhf-2021-11-08/2021-10-30-raspios-bullseye-armhf-lite.zip
 
-PUMP 800M
+PUMP 850M
 
 RUN touch /boot/ssh
 

--- a/main.Pifile
+++ b/main.Pifile
@@ -64,13 +64,12 @@ RUN bash -c "sudo chown -R ${user} /etc/automagic-ap"
 
 # Installing webmin
 
-RUN bash -c "sudo apt autoremove"
-
 RUN bash -c 'echo "deb https://download.webmin.com/download/repository sarge contrib" >> /etc/apt/sources.list'
 RUN bash -c "wget http://www.webmin.com/jcameron-key.asc"
 RUN apt-key add jcameron-key.asc
 
 RUN apt update
+RUN bash -c "sudo apt autoclean"
 RUN apt install -y webmin
 
 ##################################

--- a/main.Pifile
+++ b/main.Pifile
@@ -64,7 +64,7 @@ RUN bash -c "sudo chown -R ${user} /etc/automagic-ap"
 
 # Installing webmin
 
-RUN bash -c "truncate –size 0 /var/log/dpkg.log"
+RUN bash -c "truncate –-size 0 /var/log/dpkg.log"
 
 RUN bash -c 'echo "deb https://download.webmin.com/download/repository sarge contrib" >> /etc/apt/sources.list'
 RUN bash -c "wget http://www.webmin.com/jcameron-key.asc"

--- a/main.Pifile
+++ b/main.Pifile
@@ -69,7 +69,6 @@ RUN bash -c "wget http://www.webmin.com/jcameron-key.asc"
 RUN apt-key add jcameron-key.asc
 
 RUN apt update
-RUN bash -c "sudo apt autoclean"
 RUN apt install -y webmin
 
 ##################################


### PR DESCRIPTION
When installing webmin, it could not write to the log as it ran out of memory. Upon investigation, additional packages were being added when installing libnss-resolve that were not being added originally. This was fixed by simply increasing the memory allocated.